### PR TITLE
Update README.md - adding a Debian button next to Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This module provides a few simple math and statistics functions for other script
 
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/wouter_decoster.svg?style=social&label=Follow%20%40wouter_decoster)](https://twitter.com/wouter_decoster)
 [![install with conda](https://anaconda.org/bioconda/nanomath/badges/installer/conda.svg)](https://anaconda.org/bioconda/nanomath)
+[![install with Debian](https://www.debian.org/logos/button-mini.png)](https://tracker.debian.org/pkg/python-nanomath)
 [![Build Status](https://travis-ci.org/wdecoster/nanomath.svg?branch=master)](https://travis-ci.org/wdecoster/nanomath)
 [![Code Health](https://landscape.io/github/wdecoster/nanomath/master/landscape.svg?style=flat)](https://landscape.io/github/wdecoster/nanomath/master)
 
@@ -25,7 +26,7 @@ or
 conda install -c bioconda nanomath
 ```
 
-## STATUS
+## STATUS 
 [![Build Status](https://travis-ci.org/wdecoster/nanomath.svg?branch=master)](https://travis-ci.org/wdecoster/nanomath)
 
 


### PR DESCRIPTION
Hello again,
I had some fun with this patch, admittedly, but then again, maybe it is not needed at all. If I get this right then nanomath is not really much of an end-user's concern. It will most likely be dragged in with something else, right? I have hence not added the explicit install instructions (`sudo apt-get install python3-nanomath`) but a mere small pointer that a Debian package is available is helpful at some point, but otherwise ... whatever you think, obviously :o) 
Thanks!
Steffen